### PR TITLE
Print constant pool header

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Print one class's constant pool:
 java -jar aotp/target/aotp-0.0.1-SNAPSHOT.jar <cache.aot> --print-constant-pool "org/apache/pdfbox/tools/TextToPDF"
 ```
 
+`--print-constant-pool` prints the file map header first, then the requested class's constant pool.
+
 ## Related Work
 
 [Java AOT Cache Diagnostics Tool](https://github.com/Delawen/leyden-analyzer)

--- a/aotp/src/main/java/io/github/chains_project/aotp/AotpApi.java
+++ b/aotp/src/main/java/io/github/chains_project/aotp/AotpApi.java
@@ -16,6 +16,7 @@ import io.github.chains_project.aotp.header.GenericHeader;
 import io.github.chains_project.aotp.header.RegionData;
 import io.github.chains_project.aotp.oops.cp.ConstantPool;
 import io.github.chains_project.aotp.oops.cp.ConstantPoolEntry;
+import io.github.chains_project.aotp.oops.cp.ConstantPoolHeader;
 import io.github.chains_project.aotp.oops.klass.ClassEntry;
 import io.github.chains_project.aotp.oops.klass.InstanceClass;
 import io.github.chains_project.aotp.oops.klass.ObjArrayClass;
@@ -401,12 +402,12 @@ public final class AotpApi {
             InstanceClass klass, long requestedBaseAddress) throws IOException {
         long cpAbsAddr = klass.constants;
         if (cpAbsAddr == 0) {
-            return new ConstantPool(klass.getName(), List.of());
+            return new ConstantPool(klass.getName(), null, List.of());
         }
         long cpFileOffset = cpAbsAddr - requestedBaseAddress;
         long fileLen = file.length();
         if (cpFileOffset < 0 || cpFileOffset + CP_HEADER_SIZE > fileLen) {
-            return new ConstantPool(klass.getName(), List.of());
+            return new ConstantPool(klass.getName(), null, List.of());
         }
 
         long savedPos = file.getFilePointer();
@@ -414,20 +415,41 @@ public final class AotpApi {
             file.seek(cpFileOffset);
             file.skipBytes(8);                   // vtable pointer
             long tagsPointer = file.readLong();  // _tags
-            file.skipBytes(8 * 4);               // _cache, _pool_holder, _operands, _resolved_klasses
-            file.skipBytes(5 * 2);               // five u2 fields
+            long cachePointer = file.readLong();
+            long poolHolderPointer = file.readLong();
+            long operandsPointer = file.readLong();
+            long resolvedKlassesPointer = file.readLong();
+            int majorVersion = file.readShort() & 0xFFFF;
+            int minorVersion = file.readShort() & 0xFFFF;
+            int genericSignatureIndex = file.readShort() & 0xFFFF;
+            int sourceFileNameIndex = file.readShort() & 0xFFFF;
+            int flags = file.readShort() & 0xFFFF;
             file.skipBytes(2);                   // padding between u2 block and _length
             int length = file.readInt();         // _length  (now at offset 64)
-            file.skipBytes(4);                   // _saved   (now at offset 68)
+            int saved = file.readInt();          // _saved   (now at offset 68)
             file.skipBytes(4);                   // trailing struct padding — sizeof(ConstantPool)=72
 
+            ConstantPoolHeader cpHeader = new ConstantPoolHeader(
+                    tagsPointer,
+                    cachePointer,
+                    poolHolderPointer,
+                    operandsPointer,
+                    resolvedKlassesPointer,
+                    majorVersion,
+                    minorVersion,
+                    genericSignatureIndex,
+                    sourceFileNameIndex,
+                    flags,
+                    length,
+                    saved);
+
             if (length <= 0 || length > 100_000) {
-                return new ConstantPool(klass.getName(), List.of());
+                return new ConstantPool(klass.getName(), cpHeader, List.of());
             }
 
             byte[] tags = readTagsArray(file, tagsPointer, requestedBaseAddress, length);
             if (tags == null) {
-                return new ConstantPool(klass.getName(), List.of());
+                return new ConstantPool(klass.getName(), cpHeader, List.of());
             }
 
             long cpDataOffset = cpFileOffset + CP_HEADER_SIZE;
@@ -449,7 +471,7 @@ public final class AotpApi {
                     i++;
                 }
             }
-            return new ConstantPool(klass.getName(), entries);
+            return new ConstantPool(klass.getName(), cpHeader, entries);
         } finally {
             file.seek(savedPos);
         }

--- a/aotp/src/main/java/io/github/chains_project/aotp/Main.java
+++ b/aotp/src/main/java/io/github/chains_project/aotp/Main.java
@@ -7,6 +7,7 @@ import java.util.concurrent.Callable;
 
 import io.github.chains_project.aotp.oops.cp.ConstantPool;
 import io.github.chains_project.aotp.oops.cp.ConstantPoolEntry;
+import io.github.chains_project.aotp.oops.cp.ConstantPoolHeader;
 import io.github.chains_project.aotp.oops.klass.ClassEntry;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
@@ -57,9 +58,10 @@ public class Main implements Callable<Integer> {
     public Integer call() {
         boolean listClasses = listClassesFilter != null;
         boolean listCp = listCpFilter != null;
+        boolean printSingleCp = printConstantPoolClassName != null;
         boolean anyFlag = header || listClasses
                 || (classSizeClassNames != null && !classSizeClassNames.isEmpty())
-                || printClassName != null || listCp || printConstantPoolClassName != null;
+                || printClassName != null || listCp || printSingleCp;
         if (!anyFlag) {
             header = true;
             listClasses = true;
@@ -69,7 +71,13 @@ public class Main implements Callable<Integer> {
         try {
             if (header) {
                 AotpApi.printHeader(filePath, System.out);
-                return 0;
+                if (header && !listClasses
+                        && (classSizeClassNames == null || classSizeClassNames.isEmpty())
+                        && printClassName == null
+                        && !listCp
+                        && !printSingleCp) {
+                    return 0;
+                }
             }
 
             if (listClasses) {
@@ -103,7 +111,7 @@ public class Main implements Callable<Integer> {
                 printConstantPools(cps);
             }
 
-            if (printConstantPoolClassName != null) {
+            if (printSingleCp) {
                 List<ConstantPool> cps = AotpApi.listConstantPools(filePath, printConstantPoolClassName);
                 if (cps.isEmpty()) {
                     System.err.println("Class not found: " + printConstantPoolClassName);
@@ -152,8 +160,24 @@ public class Main implements Callable<Integer> {
     }
 
     private static void printConstantPools(List<ConstantPool> cps) {
+        // Each `cp` is the entire constant pool structure of a class.
         for (ConstantPool cp : cps) {
             System.out.println("=== " + cp.className() + " ===");
+            ConstantPoolHeader header = cp.header();
+            if (header != null) {
+                System.out.printf("  - tags:                  0x%x%n", header.tagsPointer());
+                System.out.printf("  - cache:                 0x%x%n", header.cachePointer());
+                System.out.printf("  - pool_holder:           0x%x%n", header.poolHolderPointer());
+                System.out.printf("  - operands:              0x%x%n", header.operandsPointer());
+                System.out.printf("  - resolved_klasses:      0x%x%n", header.resolvedKlassesPointer());
+                System.out.printf("  - major_version:         %d%n", header.majorVersion());
+                System.out.printf("  - minor_version:         %d%n", header.minorVersion());
+                System.out.printf("  - generic_sig_index:     %d%n", header.genericSignatureIndex());
+                System.out.printf("  - source_file_index:     %d%n", header.sourceFileNameIndex());
+                System.out.printf("  - flags:                 0x%04x%n", header.flags());
+                System.out.printf("  - length:                %d%n", header.length());
+                System.out.printf("  - saved:                 %d%n", header.saved());
+            }
             for (ConstantPoolEntry e : cp.entries()) {
                 System.out.printf("  [%4d] %-26s %s%n", e.index(), e.tagName(), e.value());
             }

--- a/aotp/src/main/java/io/github/chains_project/aotp/Main.java
+++ b/aotp/src/main/java/io/github/chains_project/aotp/Main.java
@@ -175,9 +175,11 @@ public class Main implements Callable<Integer> {
                 System.out.printf("  - generic_sig_index:     %d%n", header.genericSignatureIndex());
                 System.out.printf("  - source_file_index:     %d%n", header.sourceFileNameIndex());
                 System.out.printf("  - flags:                 0x%04x%n", header.flags());
-                System.out.printf("  - length:                %d%n", header.length());
+                System.out.printf("  - length:                %d (constant_pool_count=%d, entries=%d)%n",
+                        header.length(), header.length(), header.length() - 1);
                 System.out.printf("  - saved:                 %d%n", header.saved());
             }
+            System.out.printf("  [%4d] %-26s %s%n", 0, "Invalid", "Unused; index 0 always has this tag.");
             for (ConstantPoolEntry e : cp.entries()) {
                 System.out.printf("  [%4d] %-26s %s%n", e.index(), e.tagName(), e.value());
             }

--- a/aotp/src/main/java/io/github/chains_project/aotp/oops/cp/ConstantPool.java
+++ b/aotp/src/main/java/io/github/chains_project/aotp/oops/cp/ConstantPool.java
@@ -6,6 +6,7 @@ import java.util.List;
  * The constant pool of a single class as stored in the AOT cache.
  *
  * @param className fully-qualified class name (e.g. {@code java/lang/String})
+ * @param header    parsed constant pool header metadata (null when unavailable)
  * @param entries   ordered list of CP entries, starting at index 1
  */
-public record ConstantPool(String className, List<ConstantPoolEntry> entries) {}
+public record ConstantPool(String className, ConstantPoolHeader header, List<ConstantPoolEntry> entries) {}

--- a/aotp/src/main/java/io/github/chains_project/aotp/oops/cp/ConstantPoolHeader.java
+++ b/aotp/src/main/java/io/github/chains_project/aotp/oops/cp/ConstantPoolHeader.java
@@ -1,0 +1,18 @@
+package io.github.chains_project.aotp.oops.cp;
+
+/**
+ * Parsed metadata fields from the HotSpot {@code ConstantPool} header.
+ */
+public record ConstantPoolHeader(
+        long tagsPointer,
+        long cachePointer,
+        long poolHolderPointer,
+        long operandsPointer,
+        long resolvedKlassesPointer,
+        int majorVersion,
+        int minorVersion,
+        int genericSignatureIndex,
+        int sourceFileNameIndex,
+        int flags,
+        int length,
+        int saved) {}


### PR DESCRIPTION
```
=== org/apache/fontbox/EncodedFont ===
  - tags:                  0x800092638
  - cache:                 0x8008bcbe0
  - pool_holder:           0x8008bc9d8
  - operands:              0x0
  - resolved_klasses:      0x800092648
  - major_version:         52
  - minor_version:         0
  - generic_sig_index:     0
  - source_file_index:     8
  - flags:                 0x0006
  - length:                9
  - saved:                 0
  [   1] UnresolvedClass            0x20000
  [   2] Utf8                       org/apache/fontbox/EncodedFont
  [   3] UnresolvedClass            0x40001
  [   4] Utf8                       java/lang/Object
  [   5] Utf8                       getEncoding
  [   6] Utf8                       ()Lorg/apache/fontbox/encoding/Encoding;
  [   7] Utf8                       SourceFile
  [   8] Utf8                       EncodedFont.java
```

- [x] why is the length 9, yet only 8 entries. [`ed88f9d` (this PR)](https://github.com/chains-project/aotp/pull/15/commits/ed88f9d51c031d22c7ebb5f80c0ba8562d8990f9)
- [x] do a comparison with actual `EncodedFont` bytecode. Did a manual comparison and it seems alright to compare `Utf8` strings.